### PR TITLE
Task Based Async Refactor

### DIFF
--- a/LedgerWallet.Tests/LegacyLedgerTests.cs
+++ b/LedgerWallet.Tests/LegacyLedgerTests.cs
@@ -19,7 +19,7 @@ namespace LedgerWallet.Tests
 		public async Task TestDongleCall()
 		{
 			//Assume SetServerMode ran before
-			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var ledger = GetLedger();
 			Assert.NotNull(ledger);
 			var firmware = await ledger.GetFirmwareVersionAsync();
 			Assert.NotNull(firmware);
@@ -37,7 +37,7 @@ namespace LedgerWallet.Tests
 		public async Task SetServerMode()
 		{
 			//Assume is resetted
-			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var ledger = GetLedger();
 			var seed = GetSeed();
 			var response = ledger.RegularSetupAsync(new RegularSetup()
 			{
@@ -59,7 +59,7 @@ namespace LedgerWallet.Tests
 		public async Task CanRegularDeveloperSetup()
 		{
 			//Assume is resetted
-			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var ledger = GetLedger();
 			var response = await ledger.RegularSetupAsync(new RegularSetup()
 			{
 				OperationMode = OperationMode.Developer,
@@ -77,7 +77,7 @@ namespace LedgerWallet.Tests
 		public async Task CanGetAndSetOperation()
 		{
 			//Assume is setup
-			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var ledger = GetLedger();
 			var op = await ledger.GetOperationModeAsync();
 			var fact = await ledger.GetSecondFactorModeAsync();
 		}
@@ -86,9 +86,9 @@ namespace LedgerWallet.Tests
 		[Trait("Manual", "Manual")]
 		public async Task ResetLedger()
 		{
-			for (int i = 0; i < 3; i++)
+			for(int i = 0; i < 3; i++)
 			{
-				var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+				var ledger = GetLedger();
 				await ledger.VerifyPinAsync("1121");
 				Debugger.Break(); //Unplug and replug ledger
 			}
@@ -99,7 +99,7 @@ namespace LedgerWallet.Tests
 		public async Task CanSeeRemainingTries()
 		{
 			//Assume is setup
-			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var ledger = GetLedger();
 			var verifyPinResult = await ledger.VerifyPinAsync("1234");
 			Assert.True(verifyPinResult.IsSuccess);
 
@@ -118,6 +118,12 @@ namespace LedgerWallet.Tests
 			ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
 			verifyPinResult.Remaining = await ledger.GetRemainingAttemptsAsync();
 			Assert.Equal(2, verifyPinResult.Remaining);
+		}
+
+		private static LegacyLedgerClient GetLedger()
+		{
+			var ledger = LegacyLedgerClient.GetHIDLedgers().FirstOrDefault();
+			return ledger;
 		}
 	}
 }

--- a/LedgerWallet.Tests/LegacyLedgerTests.cs
+++ b/LedgerWallet.Tests/LegacyLedgerTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
+
 namespace LedgerWallet.Tests
 {
 	[Trait("Legacy", "Legacy")]
@@ -15,17 +16,17 @@ namespace LedgerWallet.Tests
 	{
 
 		[Fact]
-		public void TestDongleCall()
+		public async Task TestDongleCall()
 		{
 			//Assume SetServerMode ran before
-			var ledger = GetLedger();
+			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
 			Assert.NotNull(ledger);
-			var firmware = ledger.GetFirmwareVersion();
+			var firmware = await ledger.GetFirmwareVersionAsync();
 			Assert.NotNull(firmware);
 			Assert.True(firmware.ToString().Contains("Loader"));
-			Assert.True(ledger.VerifyPin("1234"));
+			Assert.True((await ledger.VerifyPinAsync("1234")).IsSuccess);
 
-			var walletPubKey = ledger.GetWalletPubKey(new KeyPath("1'/0"));
+			var walletPubKey = await ledger.GetWalletPubKeyAsync(new KeyPath("1'/0"));
 			Assert.Equal("1PcLMBsvjkqvs9MaENqHNBpa91atjm89Lb", walletPubKey.Address.ToString());
 			Assert.Equal("1PcLMBsvjkqvs9MaENqHNBpa91atjm89Lb", walletPubKey.UncompressedPublicKey.Compress().Hash.GetAddress(Network.Main).ToString());
 			Assert.Equal("1PcLMBsvjkqvs9MaENqHNBpa91atjm89Lb", new ExtKey(GetSeed()).Neuter().Derive(1).PubKey.Hash.GetAddress(Network.Main).ToString());
@@ -33,19 +34,18 @@ namespace LedgerWallet.Tests
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void SetServerMode()
+		public async Task SetServerMode()
 		{
 			//Assume is resetted
-			var ledger = GetLedger();
+			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
 			var seed = GetSeed();
-			var response = ledger.RegularSetup(new RegularSetup()
+			var response = ledger.RegularSetupAsync(new RegularSetup()
 			{
 				OperationMode = OperationMode.Server,
 				DongleFeatures = DongleFeatures.EnableAllSigHash | DongleFeatures.RFC6979 | DongleFeatures.SkipSecondFactor,
 				UserPin = new UserPin("1234"),
 				RestoredSeed = seed,
 			});
-
 		}
 
 
@@ -56,11 +56,11 @@ namespace LedgerWallet.Tests
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void CanRegularDeveloperSetup()
+		public async Task CanRegularDeveloperSetup()
 		{
 			//Assume is resetted
-			var ledger = GetLedger();
-			var response = ledger.RegularSetup(new RegularSetup()
+			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var response = await ledger.RegularSetupAsync(new RegularSetup()
 			{
 				OperationMode = OperationMode.Developer,
 				DongleFeatures = DongleFeatures.EnableAllSigHash | DongleFeatures.RFC6979 | DongleFeatures.SkipSecondFactor,
@@ -74,56 +74,50 @@ namespace LedgerWallet.Tests
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void CanGetAndSetOperation()
+		public async Task CanGetAndSetOperation()
 		{
 			//Assume is setup
-			var ledger = GetLedger();
-			var op = ledger.GetOperationMode();
-			var fact = ledger.GetSecondFactorMode();
+			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var op = await ledger.GetOperationModeAsync();
+			var fact = await ledger.GetSecondFactorModeAsync();
 		}
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void ResetLedger()
+		public async Task ResetLedger()
 		{
-			for(int i = 0; i < 3; i++)
+			for (int i = 0; i < 3; i++)
 			{
-				var ledger = GetLedger();
-				ledger.VerifyPin("1121");
+				var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+				await ledger.VerifyPinAsync("1121");
 				Debugger.Break(); //Unplug and replug ledger
 			}
 		}
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void CanSeeRemainingTries()
+		public async Task CanSeeRemainingTries()
 		{
 			//Assume is setup
-			var ledger = GetLedger();
-			Assert.True(ledger.VerifyPin("1234"));
+			var ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			var verifyPinResult = await ledger.VerifyPinAsync("1234");
+			Assert.True(verifyPinResult.IsSuccess);
 
-			int tries;
-			tries = ledger.GetRemainingAttempts();
-			Assert.Equal(3, tries);
-			ledger.VerifyPin("1235", out tries);
-			Assert.Equal(2, tries);
+			verifyPinResult.Remaining = await ledger.GetRemainingAttemptsAsync();
+			Assert.Equal(3, verifyPinResult.Remaining);
+			var result = await ledger.VerifyPinAsync("1235");
+			Assert.Equal(2, verifyPinResult.Remaining);
 
-			var ex = Assert.Throws<LedgerWalletException>(() => tries = ledger.GetRemainingAttempts());
+			var ex = await Assert.ThrowsAsync<LedgerWalletException>(async () => verifyPinResult.Remaining = await ledger.GetRemainingAttemptsAsync());
 			Assert.NotNull(ex.Status);
 			Assert.NotNull(ex.Status.SW == 0x6FAA);
 			Assert.NotNull(ex.Status.InternalSW == 0x00AA);
 
 			Debugger.Break(); //Remove then insert
 
-			ledger = GetLedger();
-			tries = ledger.GetRemainingAttempts();
-			Assert.Equal(2, tries);
-		}
-
-		private static LegacyLedgerClient GetLedger()
-		{
-			var ledger = LegacyLedgerClient.GetHIDLedgers().FirstOrDefault();
-			return ledger;
+			ledger = (LegacyLedgerClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.LegacyLedger);
+			verifyPinResult.Remaining = await ledger.GetRemainingAttemptsAsync();
+			Assert.Equal(2, verifyPinResult.Remaining);
 		}
 	}
 }

--- a/LedgerWallet.Tests/NanoSTests.cs
+++ b/LedgerWallet.Tests/NanoSTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+
 namespace LedgerWallet.Tests
 {
 	[Trait("NanoS", "NanoS")]
@@ -17,77 +18,49 @@ namespace LedgerWallet.Tests
 	{
 
 		[Fact]
-		public void LedgerIsThreadSafe()
+		public async Task LedgerIsThreadSafe()
 		{
-			var ledger = GetLedger();
-			List<Task> tasks = new List<Task>();
-			bool exception = false;
+			var ledger = (LedgerClient)await GetLedgerAsync(LedgerType.Ledger);
 
-			Thread t1 = new Thread(() =>
+			var tasks = new List<Task>();
+
+			for (int i = 0; i < 50; i++)
 			{
-				try
-				{
-					for(int i = 0; i < 50; i++)
-					{
-						GetLedger().GetFirmwareVersion();
-					}
-				}
-				catch
-				{
-					exception = true;
-				}
-			});
-			t1.Start();
+				tasks.Add(ledger.GetWalletPubKeyAsync(new KeyPath("1'/0")));
+				tasks.Add(ledger.GetFirmwareVersionAsync());
+			}
 
-			Thread t2 = new Thread(() =>
-			{
-				try
-				{
-
-					for(int i = 0; i < 50; i++)
-					{
-						ledger.GetWalletPubKey(new KeyPath("1'/0"));
-					}
-				}
-				catch
-				{
-					exception = true;
-				}
-			});
-			t2.Start();
-
-			t1.Join();
-			t2.Join();
-			Assert.False(exception);
+			await Task.WhenAll(tasks);
 		}
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void CanSignTransactionStandardMode()
+		public async Task CanSignTransactionStandardMode()
 		{
-			CanSignTransactionStandardModeCore(true);
-			CanSignTransactionStandardModeCore(false);
+			await CanSignTransactionStandardModeCore(true);
+			await CanSignTransactionStandardModeCore(false);
 		}
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void CanGetWalletPubKey()
+		public async Task CanGetWalletPubKey()
 		{
-			var ledger = GetLedger();
-			ledger.GetFirmwareVersion();
+			var ledger = (LedgerClient)await GetLedgerAsync(LedgerType.Ledger);
+			var firmwareVersion = ledger.GetFirmwareVersionAsync();
 			var path = new KeyPath("1'/0");
-			ledger.GetWalletPubKey(path, LedgerClient.AddressType.Legacy, true);
-			ledger.GetWalletPubKey(path, LedgerClient.AddressType.NativeSegwit, false);
-			ledger.GetWalletPubKey(path, LedgerClient.AddressType.Segwit, false);
+			var walletPubKeyResponse = ledger.GetWalletPubKeyAsync(path, LedgerClient.AddressType.Legacy, true);
+			await ledger.GetWalletPubKeyAsync(path, LedgerClient.AddressType.NativeSegwit, false);
+			await ledger.GetWalletPubKeyAsync(path, LedgerClient.AddressType.Segwit, false);
 		}
 
-		public void CanSignTransactionStandardModeCore(bool segwit)
+		public async Task CanSignTransactionStandardModeCore(bool segwit)
 		{
-			var ledger = GetLedger();
-			var walletPubKey = ledger.GetWalletPubKey(new KeyPath("1'/0"));
+			var ledger = (LedgerClient)await GetLedgerAsync(LedgerType.Ledger);
+			var walletPubKey = await ledger.GetWalletPubKeyAsync(new KeyPath("1'/0"));
 			var address = segwit ? walletPubKey.UncompressedPublicKey.Compress().WitHash.ScriptPubKey : walletPubKey.GetAddress(network).ScriptPubKey;
 
-			var changeAddress = ledger.GetWalletPubKey(new KeyPath("1'/1")).GetAddress(network);
+			var response = await ledger.GetWalletPubKeyAsync(new KeyPath("1'/1"));
+			var changeAddress = response.GetAddress(network);
 
 			Transaction funding = new Transaction();
 			funding.AddInput(Network.Main.GetGenesis().Transactions[0].Inputs[0]);
@@ -101,7 +74,6 @@ namespace LedgerWallet.Tests
 			spending.LockTime = 1;
 			spending.Inputs.AddRange(coins.Select(o => new TxIn(o.Outpoint, Script.Empty)));
 			spending.Inputs[0].Sequence = 1;
-			//spending.Inputs.Add(new TxIn(new OutPoint(uint256.Zero, 0), Script.Empty));
 			spending.Outputs.Add(new TxOut(Money.Coins(0.5m), BitcoinAddress.Create("15sYbVpRh6dyWycZMwPdxJWD4xbfxReeHe", Network.Main)));
 			spending.Outputs.Add(new TxOut(Money.Coins(0.8m), changeAddress));
 			spending.Outputs.Add(new TxOut(Money.Zero, TxNullDataTemplate.Instance.GenerateScriptPubKey(new byte[] { 1, 2 })));
@@ -128,14 +100,14 @@ namespace LedgerWallet.Tests
 				},
 			};
 
-			if(segwit)
+			if (segwit)
 			{
-				foreach(var req in requests)
+				foreach (var req in requests)
 					req.InputTransaction = null;
 			}
 
 			//should show 0.5 and 2.0 btc in fee
-			var signed = ledger.SignTransaction(requests, spending, new KeyPath("1'/1"));
+			var signed = await ledger.SignTransactionAsync(requests, spending, new KeyPath("1'/1"));
 			//Assert.Equal(Script.Empty, spending.Inputs.Last().ScriptSig);
 			Assert.NotNull(signed);
 		}
@@ -144,14 +116,15 @@ namespace LedgerWallet.Tests
 
 		[Fact]
 		[Trait("Manual", "Manual")]
-		public void CanSignTransactionStandardModeConcurrently()
+		public async Task CanSignTransactionStandardModeConcurrently()
 		{
-			var ledger = GetLedger();
+			var ledger = (LedgerClient)await GetLedgerAsync(LedgerType.Ledger);
 
-			var walletPubKey = ledger.GetWalletPubKey(new KeyPath("1'/0"));
+			var walletPubKey = await ledger.GetWalletPubKeyAsync(new KeyPath("1'/0"));
 			var address = walletPubKey.GetAddress(network);
 
-			var changeAddress = ledger.GetWalletPubKey(new KeyPath("1'/1")).GetAddress(network);
+			var walletPubKey2 = await ledger.GetWalletPubKeyAsync(new KeyPath("1'/1"));
+			var changeAddress = walletPubKey2.GetAddress(network);
 
 			Transaction funding = new Transaction();
 			funding.AddInput(network.GetGenesis().Transactions[0].Inputs[0]);
@@ -168,10 +141,12 @@ namespace LedgerWallet.Tests
 			spending.Outputs.Add(new TxOut(Money.Coins(0.8m), changeAddress));
 			spending.Outputs.Add(new TxOut(Money.Zero, TxNullDataTemplate.Instance.GenerateScriptPubKey(new byte[] { 1, 2 })));
 
-			Parallel.For(0, 5, i =>
+			var tasks = new List<Task>();
+
+			for (var i = 0; i < 5; i++)
 			{
 				//should show 0.5 and 2.0 btc in fee
-				var signed = ledger.SignTransaction(
+				var signed = ledger.SignTransactionAsync(
 				  new KeyPath("1'/0"),
 				  new Coin[]
 				{
@@ -182,12 +157,23 @@ namespace LedgerWallet.Tests
 				{
 				funding
 				}, spending, new KeyPath("1'/1"));
-			});
+
+				tasks.Add(signed);
+			}
+
+			await Task.WhenAll(tasks);
 		}
 
-		private static LedgerClient GetLedger()
+		public async static Task<LedgerClientBase> GetLedgerAsync(LedgerType ledgerType)
 		{
 			return LedgerClient.GetHIDLedgers().First();
+		}
+
+		public enum LedgerType
+		{
+			Ledger,
+			LegacyLedger,
+			U2F
 		}
 	}
 }

--- a/LedgerWallet.Tests/U2FTests.cs
+++ b/LedgerWallet.Tests/U2FTests.cs
@@ -12,39 +12,39 @@ using Xunit;
 
 namespace LedgerWallet.Tests
 {
-    [Trait("U2F", "U2F")]
-    public class U2FTests
-    {
-        [Fact]
-        [Trait("Manual", "Manual")]
-        public async Task CanEnrollAndAuthenticate()
-        {
-            var appId = new AppId(Encoders.Hex.DecodeData("d2e42c173c857991d5e1b6c81f3e07cbb9d5f57431fe41997c9445c14ce61ec4"));
-            var challenge = Encoders.Hex.DecodeData("e6425678fbd7d3d8e311fbfb1db8d26c37cf9f16ac81c95848998a76ce3d3768");
-            var u2f = (U2FClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.U2F);
+	[Trait("U2F", "U2F")]
+	public class U2FTests
+	{
+		[Fact]
+		[Trait("Manual", "Manual")]
+		public async Task CanEnrollAndAuthenticate()
+		{
+			var appId = new AppId(Encoders.Hex.DecodeData("d2e42c173c857991d5e1b6c81f3e07cbb9d5f57431fe41997c9445c14ce61ec4"));
+			var challenge = Encoders.Hex.DecodeData("e6425678fbd7d3d8e311fbfb1db8d26c37cf9f16ac81c95848998a76ce3d3768");
+			var u2f = (U2FClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.U2F);
 
-            // Refuse registration
-            Debugger.Break();
-            CancellationTokenSource cts = new CancellationTokenSource();
-            cts.CancelAfter(5000);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await u2f.RegisterAsync(challenge, appId, cts.Token));
+			// Refuse registration
+			Debugger.Break();
+			CancellationTokenSource cts = new CancellationTokenSource();
+			cts.CancelAfter(5000);
+			await Assert.ThrowsAsync<OperationCanceledException>(async () => await u2f.RegisterAsync(challenge, appId, cts.Token));
 
-            // Accept registration
-            Debugger.Break();
-            var reg = await u2f.RegisterAsync(challenge, appId);
-            Assert.NotNull(reg);
+			// Accept registration
+			Debugger.Break();
+			var reg = await u2f.RegisterAsync(challenge, appId);
+			Assert.NotNull(reg);
 
-            // Refuse login
-            Debugger.Break();
-            cts = new CancellationTokenSource();
-            cts.CancelAfter(5000);
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await u2f.AuthenticateAsync(challenge, appId, reg.KeyHandle, cts.Token));
+			// Refuse login
+			Debugger.Break();
+			cts = new CancellationTokenSource();
+			cts.CancelAfter(5000);
+			await Assert.ThrowsAsync<OperationCanceledException>(async () => await u2f.AuthenticateAsync(challenge, appId, reg.KeyHandle, cts.Token));
 
-            // Accept registration
-            Debugger.Break();
-            var login = await u2f.AuthenticateAsync(challenge, appId, reg.KeyHandle);
-            Assert.NotNull(login);
-            Assert.True(login.UserPresence);
-        }
-    }
+			// Accept registration
+			Debugger.Break();
+			var login = await u2f.AuthenticateAsync(challenge, appId, reg.KeyHandle);
+			Assert.NotNull(login);
+			Assert.True(login.UserPresence);
+		}
+	}
 }

--- a/LedgerWallet.Tests/U2FTests.cs
+++ b/LedgerWallet.Tests/U2FTests.cs
@@ -12,39 +12,39 @@ using Xunit;
 
 namespace LedgerWallet.Tests
 {
-	[Trait("U2F", "U2F")]
-	public class U2FTests
-	{
-		[Fact]
-		[Trait("Manual", "Manual")]
-		public void CanEnrollAndAuthenticate()
-		{
-			var appId = new AppId(Encoders.Hex.DecodeData("d2e42c173c857991d5e1b6c81f3e07cbb9d5f57431fe41997c9445c14ce61ec4"));
-			var challenge = Encoders.Hex.DecodeData("e6425678fbd7d3d8e311fbfb1db8d26c37cf9f16ac81c95848998a76ce3d3768");
-			U2FClient u2f = U2FClient.GetHIDU2F().First();
+    [Trait("U2F", "U2F")]
+    public class U2FTests
+    {
+        [Fact]
+        [Trait("Manual", "Manual")]
+        public async Task CanEnrollAndAuthenticate()
+        {
+            var appId = new AppId(Encoders.Hex.DecodeData("d2e42c173c857991d5e1b6c81f3e07cbb9d5f57431fe41997c9445c14ce61ec4"));
+            var challenge = Encoders.Hex.DecodeData("e6425678fbd7d3d8e311fbfb1db8d26c37cf9f16ac81c95848998a76ce3d3768");
+            var u2f = (U2FClient)await NanoSTests.GetLedgerAsync(NanoSTests.LedgerType.U2F);
 
-			// Refuse registration
-			Debugger.Break();
-			CancellationTokenSource cts = new CancellationTokenSource();
-			cts.CancelAfter(5000);
-			Assert.Throws<OperationCanceledException>(() => u2f.Register(challenge, appId, cts.Token));
+            // Refuse registration
+            Debugger.Break();
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.CancelAfter(5000);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await u2f.RegisterAsync(challenge, appId, cts.Token));
 
-			// Accept registration
-			Debugger.Break();
-			var reg = u2f.Register(challenge, appId);
-			Assert.NotNull(reg);
+            // Accept registration
+            Debugger.Break();
+            var reg = await u2f.RegisterAsync(challenge, appId);
+            Assert.NotNull(reg);
 
-			// Refuse login
-			Debugger.Break();
-			cts = new CancellationTokenSource();
-			cts.CancelAfter(5000);
-			Assert.Throws<OperationCanceledException>(() => u2f.Authenticate(challenge, appId, reg.KeyHandle, cts.Token));
+            // Refuse login
+            Debugger.Break();
+            cts = new CancellationTokenSource();
+            cts.CancelAfter(5000);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await u2f.AuthenticateAsync(challenge, appId, reg.KeyHandle, cts.Token));
 
-			// Accept registration
-			Debugger.Break();
-			var login = u2f.Authenticate(challenge, appId, reg.KeyHandle);
-			Assert.NotNull(login);
-			Assert.True(login.UserPresence);
-		}
-	}
+            // Accept registration
+            Debugger.Break();
+            var login = await u2f.AuthenticateAsync(challenge, appId, reg.KeyHandle);
+            Assert.NotNull(login);
+            Assert.True(login.UserPresence);
+        }
+    }
 }

--- a/LedgerWallet.Tests/UnitTest1.cs
+++ b/LedgerWallet.Tests/UnitTest1.cs
@@ -3,12 +3,12 @@ using Xunit;
 
 namespace LedgerWallet.Tests
 {
-    public class UnitTest1
-    {
-        [Fact]
-        public void Test1()
-        {
+	public class UnitTest1
+	{
+		[Fact]
+		public void Test1()
+		{
 
-        }
-    }
+		}
+	}
 }

--- a/LedgerWallet/LedgacyLedgerClient.cs
+++ b/LedgerWallet/LedgacyLedgerClient.cs
@@ -17,6 +17,14 @@ namespace LedgerWallet
 		{
 		}
 
+		public static new IEnumerable<LegacyLedgerClient> GetHIDLedgers()
+		{
+			var ledgers = HIDLedgerTransport.GetHIDTransports()
+							.Select(t => new LegacyLedgerClient(t))
+							.ToList();
+			return ledgers;
+		}
+
 		public Task<VerifyPinResult> VerifyPinAsync(string pin)
 		{
 			return VerifyPinAsync(new UserPin(pin));

--- a/LedgerWallet/LedgacyLedgerClient.cs
+++ b/LedgerWallet/LedgacyLedgerClient.cs
@@ -32,7 +32,7 @@ namespace LedgerWallet
 		public bool VerifyPin(UserPin pin, out int remaining)
 		{
 			remaining = 3;
-			var response = ExchangeSingleAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_VERIFY_PIN, 0, 0, pin.ToBytes()).GetAwaiter().GetResult();
+			var response = ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_VERIFY_PIN, 0, 0, pin.ToBytes()).GetAwaiter().GetResult();
 			if(response.SW == LedgerWalletConstants.SW_OK)
 				return true;
 			if(response.SW == LedgerWalletConstants.SW_INS_NOT_SUPPORTED)
@@ -42,7 +42,7 @@ namespace LedgerWallet
 		}
 		public int GetRemainingAttempts()
 		{
-			var response = ExchangeSingleAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_VERIFY_PIN, 0x80, 0, new byte[] { 1 }).GetAwaiter().GetResult();
+			var response = ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_VERIFY_PIN, 0x80, 0, new byte[] { 1 }).GetAwaiter().GetResult();
 			return (response.SW & 0x0F);
 		}
 		public bool VerifyPin(string pin)
@@ -62,13 +62,13 @@ namespace LedgerWallet
 		}
 		public async Task<OperationMode> GetOperationModeAsync()
 		{
-			var response = await ExchangeSingleAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_OPERATION_MODE, 0, 0, 0, OK).ConfigureAwait(false);
+			var response = await ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_OPERATION_MODE, 0, 0, 0, OK).ConfigureAwait(false);
 			return (OperationMode)response[0];
 		}
 
 		public async Task<SecondFactorMode> GetSecondFactorModeAsync()
 		{
-			var response = await ExchangeSingleAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_OPERATION_MODE, 1, 0, 0, OK).ConfigureAwait(false);
+			var response = await ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_OPERATION_MODE, 1, 0, 0, OK).ConfigureAwait(false);
 			return (SecondFactorMode)response[0];
 		}
 		public SecondFactorMode GetSecondFactorMode()
@@ -78,7 +78,7 @@ namespace LedgerWallet
 
 		public void SetOperationMode(OperationMode value)
 		{
-			ExchangeSingleAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_SET_OPERATION_MODE, 0, 0, new[] { (byte)value }, OK);
+			ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_SET_OPERATION_MODE, 0, 0, new[] { (byte)value }, OK);
 		}
 
 		public SetupResponse RegularSetup(RegularSetup setup)
@@ -87,7 +87,7 @@ namespace LedgerWallet
 		}
 		public async Task<SetupResponse> RegularSetupAsync(RegularSetup setup)
 		{
-			var response = await ExchangeSingleAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_SETUP, 0, 0, setup.ToBytes(), OK).ConfigureAwait(false);
+			var response = await ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_SETUP, 0, 0, setup.ToBytes(), OK).ConfigureAwait(false);
 			return new SetupResponse(response);
 		}
 	}

--- a/LedgerWallet/LedgerClient.cs
+++ b/LedgerWallet/LedgerClient.cs
@@ -31,7 +31,7 @@ namespace LedgerWallet
 
 		public async Task<LedgerWalletFirmware> GetFirmwareVersionAsync()
 		{
-			byte[] response = await ExchangeSingleAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_FIRMWARE_VERSION, (byte)0x00, (byte)0x00, 0x00, OK).ConfigureAwait(false);
+			byte[] response = await ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_FIRMWARE_VERSION, (byte)0x00, (byte)0x00, 0x00, OK).ConfigureAwait(false);
 			return new LedgerWalletFirmware(response);
 		}
 		public LedgerWalletFirmware GetFirmwareVersion()
@@ -60,7 +60,7 @@ namespace LedgerWallet
 			Guard.AssertKeyPath(keyPath);
 			byte[] bytes = Serializer.Serialize(keyPath);
 			//bytes[0] = 10;
-			byte[] response = await ExchangeSingleAPDU(
+			byte[] response = await ExchangeSingleAPDUAsync(
 				LedgerWalletConstants.LedgerWallet_CLA,
 				LedgerWalletConstants.LedgerWallet_INS_GET_WALLET_PUBLIC_KEY,
 				(byte)(display ? 1 : 0),
@@ -169,7 +169,7 @@ namespace LedgerWallet
 			}
 			// Locktime
 			apdus.Add(CreateAPDU(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_TRUSTED_INPUT, (byte)0x80, (byte)0x00, transaction.LockTime.ToBytes()));
-			byte[] response = await ExchangeApdus(apdus.ToArray(), OK).ConfigureAwait(false);
+			byte[] response = await ExchangeApdusAsync(apdus.ToArray(), OK).ConfigureAwait(false);
 			return new TrustedInput(response);
 		}
 
@@ -363,7 +363,7 @@ namespace LedgerWallet
 				}
 				apdus.Add(UntrustedHashSign(sigRequest.KeyPath, null, transaction.LockTime, SigHash.All));
 			}
-			var responses = await Exchange(apdus.ToArray()).ConfigureAwait(false);
+			var responses = await ExchangeAsync(apdus.ToArray()).ConfigureAwait(false);
 			foreach(var response in responses)
 				if(response.Response.Length > 10) //Probably a signature
 					response.Response[0] = 0x30;

--- a/LedgerWallet/LedgerClient.cs
+++ b/LedgerWallet/LedgerClient.cs
@@ -255,7 +255,6 @@ namespace LedgerWallet
 			}
 			return apdus.ToArray();
 		}
-
 		public async Task<Transaction> SignTransactionAsync(KeyPath keyPath, ICoin[] signedCoins, Transaction[] parents, Transaction transaction, KeyPath changePath = null)
 		{
 			List<SignatureRequest> requests = new List<SignatureRequest>();

--- a/LedgerWallet/LedgerClient.cs
+++ b/LedgerWallet/LedgerClient.cs
@@ -34,18 +34,6 @@ namespace LedgerWallet
 			byte[] response = await ExchangeSingleAPDUAsync(LedgerWalletConstants.LedgerWallet_CLA, LedgerWalletConstants.LedgerWallet_INS_GET_FIRMWARE_VERSION, (byte)0x00, (byte)0x00, 0x00, OK).ConfigureAwait(false);
 			return new LedgerWalletFirmware(response);
 		}
-		public LedgerWalletFirmware GetFirmwareVersion()
-		{
-			return GetFirmwareVersionAsync().GetAwaiter().GetResult();
-		}
-		public GetWalletPubKeyResponse GetWalletPubKey(KeyPath keyPath)
-		{
-			return GetWalletPubKeyAsync(keyPath).GetAwaiter().GetResult();
-		}
-		public GetWalletPubKeyResponse GetWalletPubKey(KeyPath keyPath, AddressType displayMode = AddressType.Legacy, bool display = false)
-		{
-			return GetWalletPubKeyAsync(keyPath, displayMode, display).GetAwaiter().GetResult();
-		}
 
 		[Flags]
 		public enum AddressType
@@ -68,19 +56,9 @@ namespace LedgerWallet
 			return new GetWalletPubKeyResponse(response);
 		}
 
-		public GetWalletPubKeyResponse GetWalletMasterKey()
-		{
-			return GetWalletMasterKeyAsync().GetAwaiter().GetResult();
-		}
-
 		public async Task<GetWalletPubKeyResponse> GetWalletMasterKeyAsync()
 		{
 			return await GetWalletPubKeyAsync(new KeyPath("0'"));
-		}
-
-		public KeyPath GetWalletHDKeyPathForSegwitAddress(KeyPath rootKeyPath, string segwitAddress, Network network, int startAtIndex = 0, int maxAttempts = 100)
-		{
-			return GetWalletHDKeyPathForSegwitAddressAsync(rootKeyPath, segwitAddress, network, startAtIndex, maxAttempts).GetAwaiter().GetResult();
 		}
 
 		public async Task<KeyPath> GetWalletHDKeyPathForSegwitAddressAsync(KeyPath rootKeyPath, string segwitAddress, Network network, int startAtIndex = 0, int? maxAttempts = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -277,11 +255,8 @@ namespace LedgerWallet
 			}
 			return apdus.ToArray();
 		}
-		public Transaction SignTransaction(KeyPath keyPath, ICoin[] signedCoins, Transaction[] parents, Transaction transaction, KeyPath changePath = null)
-		{
-			return SignTransactionAsync(keyPath, signedCoins, parents, transaction, changePath).GetAwaiter().GetResult();
-		}
-		public Task<Transaction> SignTransactionAsync(KeyPath keyPath, ICoin[] signedCoins, Transaction[] parents, Transaction transaction, KeyPath changePath = null)
+
+		public async Task<Transaction> SignTransactionAsync(KeyPath keyPath, ICoin[] signedCoins, Transaction[] parents, Transaction transaction, KeyPath changePath = null)
 		{
 			List<SignatureRequest> requests = new List<SignatureRequest>();
 			foreach(var c in signedCoins)
@@ -295,12 +270,9 @@ namespace LedgerWallet
 						KeyPath = keyPath
 					});
 			}
-			return SignTransactionAsync(requests.ToArray(), transaction, changePath: changePath);
+			return await SignTransactionAsync(requests.ToArray(), transaction, changePath: changePath);
 		}
-		public Transaction SignTransaction(SignatureRequest[] signatureRequests, Transaction transaction, KeyPath changePath = null)
-		{
-			return SignTransactionAsync(signatureRequests, transaction, changePath).GetAwaiter().GetResult();
-		}
+
 		public async Task<Transaction> SignTransactionAsync(SignatureRequest[] signatureRequests, Transaction transaction, KeyPath changePath = null)
 		{
 			if(signatureRequests.Length == 0)

--- a/LedgerWallet/LedgerClientBase.cs
+++ b/LedgerWallet/LedgerClientBase.cs
@@ -186,7 +186,7 @@ namespace LedgerWallet
 		}
 		protected async Task<APDUResponse[]> ExchangeAsync(byte[][] apdus)
 		{
-			byte[][] responses = await Transport.ExchangeAsync(apdus).ConfigureAwait(false);
+			byte[][] responses = await Transport.Exchange(apdus).ConfigureAwait(false);
 			List<APDUResponse> resultResponses = new List<APDUResponse>();
 			foreach(var response in responses)
 			{

--- a/LedgerWallet/LedgerClientBase.cs
+++ b/LedgerWallet/LedgerClientBase.cs
@@ -32,7 +32,7 @@ namespace LedgerWallet
 
 		public LedgerClientBase(ILedgerTransport transport)
 		{
-			if(transport == null)
+			if (transport == null)
 				throw new ArgumentNullException("transport");
 			this._Transport = transport;
 		}
@@ -53,7 +53,7 @@ namespace LedgerWallet
 		{
 			int offset = 0;
 			List<byte[]> result = new List<byte[]>();
-			while(offset < data.Length)
+			while (offset < data.Length)
 			{
 				int blockLength = ((data.Length - offset) > 255 ? 255 : data.Length - offset);
 				byte[] apdu = new byte[blockLength + 5];
@@ -74,7 +74,7 @@ namespace LedgerWallet
 			int offset = 0;
 			int maxBlockSize = 255 - data2.Length;
 			List<byte[]> apdus = new List<byte[]>();
-			while(offset < data.Length)
+			while (offset < data.Length)
 			{
 				int blockLength = ((data.Length - offset) > maxBlockSize ? maxBlockSize : data.Length - offset);
 				var lastBlock = ((offset + blockLength) == data.Length);
@@ -85,7 +85,7 @@ namespace LedgerWallet
 				apdu[3] = p2;
 				apdu[4] = (byte)(blockLength + (lastBlock ? data2.Length : 0));
 				Array.Copy(data, offset, apdu, 5, blockLength);
-				if(lastBlock)
+				if (lastBlock)
 				{
 					Array.Copy(data2, 0, apdu, 5 + blockLength, data2.Length);
 				}
@@ -103,7 +103,7 @@ namespace LedgerWallet
 
 		protected void CheckSW(int[] acceptedSW, int sw)
 		{
-			if(!acceptedSW.Contains(sw))
+			if (!acceptedSW.Contains(sw))
 			{
 				Throw(sw);
 			}
@@ -111,7 +111,7 @@ namespace LedgerWallet
 
 		protected virtual string GetErrorMessage(LedgerWalletStatus status)
 		{
-			switch(status.SW)
+			switch (status.SW)
 			{
 				case 0x6D00:
 					return "INS not supported";
@@ -133,9 +133,9 @@ namespace LedgerWallet
 					return "OK";
 				default:
 					{
-						if((status.SW & 0xFF00) != 0x6F00)
+						if ((status.SW & 0xFF00) != 0x6F00)
 							return "Unknown error";
-						switch(status.InternalSW)
+						switch (status.InternalSW)
 						{
 							case 0xAA:
 								return "The dongle must be reinserted";
@@ -177,9 +177,9 @@ namespace LedgerWallet
 		{
 			var responses = await ExchangeAsync(apdus).ConfigureAwait(false);
 			var last = responses.Last();
-			foreach(var response in responses)
+			foreach (var response in responses)
 			{
-				if(response != last)
+				if (response != last)
 					CheckSW(OK, response.SW);
 			}
 			return last;
@@ -189,15 +189,15 @@ namespace LedgerWallet
 		{
 			byte[][] responses = await Transport.ExchangeAsync(apdus).ConfigureAwait(false);
 			List<APDUResponse> resultResponses = new List<APDUResponse>();
-			foreach(var response in responses)
+			foreach (var response in responses)
 			{
-				if(response.Length < 2)
+				if (response.Length < 2)
 				{
 					throw new LedgerWalletException("Truncated response");
 				}
 				int sw = ((int)(response[response.Length - 2] & 0xff) << 8) |
 						(int)(response[response.Length - 1] & 0xff);
-				if(sw == 0x6faa)
+				if (sw == 0x6faa)
 					Throw(sw);
 				byte[] result = new byte[response.Length - 2];
 				Array.Copy(response, 0, result, 0, response.Length - 2);

--- a/LedgerWallet/LedgerClientBase.cs
+++ b/LedgerWallet/LedgerClientBase.cs
@@ -147,35 +147,35 @@ namespace LedgerWallet
 		}
 
 
-		protected Task<byte[]> ExchangeSingleAPDU(byte cla, byte ins, byte p1, byte p2, byte[] data, int[] acceptedSW)
+		protected Task<byte[]> ExchangeSingleAPDUAsync(byte cla, byte ins, byte p1, byte p2, byte[] data, int[] acceptedSW)
 		{
-			return ExchangeApdus(new byte[][] { CreateAPDU(cla, ins, p1, p2, data) }, acceptedSW);
+			return ExchangeApdusAsync(new byte[][] { CreateAPDU(cla, ins, p1, p2, data) }, acceptedSW);
 		}
 
-		protected Task<APDUResponse> ExchangeSingleAPDU(byte cla, byte ins, byte p1, byte p2, byte[] data)
+		protected Task<APDUResponse> ExchangeSingleAPDUAsync(byte cla, byte ins, byte p1, byte p2, byte[] data)
 		{
-			return ExchangeSingle(new byte[][] { CreateAPDU(cla, ins, p1, p2, data) });
+			return ExchangeSingleAsync(new byte[][] { CreateAPDU(cla, ins, p1, p2, data) });
 		}
 
-		protected Task<byte[]> ExchangeSingleAPDU(byte cla, byte ins, byte p1, byte p2, int length, int[] acceptedSW)
+		protected Task<byte[]> ExchangeSingleAPDUAsync(byte cla, byte ins, byte p1, byte p2, int length, int[] acceptedSW)
 		{
 			byte[] apdu = new byte[]
 			{
 				cla,ins,p1,p2,(byte)length
 			};
-			return ExchangeApdus(new byte[][] { apdu }, acceptedSW);
+			return ExchangeApdusAsync(new byte[][] { apdu }, acceptedSW);
 		}
 
-		protected async Task<byte[]> ExchangeApdus(byte[][] apdus, int[] acceptedSW)
+		protected async Task<byte[]> ExchangeApdusAsync(byte[][] apdus, int[] acceptedSW)
 		{
-			var resp = await ExchangeSingle(apdus).ConfigureAwait(false);
+			var resp = await ExchangeSingleAsync(apdus).ConfigureAwait(false);
 			CheckSW(acceptedSW, resp.SW);
 			return resp.Response;
 		}
 
-		protected async Task<APDUResponse> ExchangeSingle(byte[][] apdus)
+		protected async Task<APDUResponse> ExchangeSingleAsync(byte[][] apdus)
 		{
-			var responses = await Exchange(apdus).ConfigureAwait(false);
+			var responses = await ExchangeAsync(apdus).ConfigureAwait(false);
 			var last = responses.Last();
 			foreach(var response in responses)
 			{
@@ -184,9 +184,10 @@ namespace LedgerWallet
 			}
 			return last;
 		}
-		protected async Task<APDUResponse[]> Exchange(byte[][] apdus)
+
+		protected async Task<APDUResponse[]> ExchangeAsync(byte[][] apdus)
 		{
-			byte[][] responses = await Transport.Exchange(apdus).ConfigureAwait(false);
+			byte[][] responses = await Transport.ExchangeAsync(apdus).ConfigureAwait(false);
 			List<APDUResponse> resultResponses = new List<APDUResponse>();
 			foreach(var response in responses)
 			{

--- a/LedgerWallet/LedgerClientBase.cs
+++ b/LedgerWallet/LedgerClientBase.cs
@@ -32,7 +32,7 @@ namespace LedgerWallet
 
 		public LedgerClientBase(ILedgerTransport transport)
 		{
-			if (transport == null)
+			if(transport == null)
 				throw new ArgumentNullException("transport");
 			this._Transport = transport;
 		}
@@ -53,7 +53,7 @@ namespace LedgerWallet
 		{
 			int offset = 0;
 			List<byte[]> result = new List<byte[]>();
-			while (offset < data.Length)
+			while(offset < data.Length)
 			{
 				int blockLength = ((data.Length - offset) > 255 ? 255 : data.Length - offset);
 				byte[] apdu = new byte[blockLength + 5];
@@ -74,7 +74,7 @@ namespace LedgerWallet
 			int offset = 0;
 			int maxBlockSize = 255 - data2.Length;
 			List<byte[]> apdus = new List<byte[]>();
-			while (offset < data.Length)
+			while(offset < data.Length)
 			{
 				int blockLength = ((data.Length - offset) > maxBlockSize ? maxBlockSize : data.Length - offset);
 				var lastBlock = ((offset + blockLength) == data.Length);
@@ -85,7 +85,7 @@ namespace LedgerWallet
 				apdu[3] = p2;
 				apdu[4] = (byte)(blockLength + (lastBlock ? data2.Length : 0));
 				Array.Copy(data, offset, apdu, 5, blockLength);
-				if (lastBlock)
+				if(lastBlock)
 				{
 					Array.Copy(data2, 0, apdu, 5 + blockLength, data2.Length);
 				}
@@ -103,7 +103,7 @@ namespace LedgerWallet
 
 		protected void CheckSW(int[] acceptedSW, int sw)
 		{
-			if (!acceptedSW.Contains(sw))
+			if(!acceptedSW.Contains(sw))
 			{
 				Throw(sw);
 			}
@@ -111,7 +111,7 @@ namespace LedgerWallet
 
 		protected virtual string GetErrorMessage(LedgerWalletStatus status)
 		{
-			switch (status.SW)
+			switch(status.SW)
 			{
 				case 0x6D00:
 					return "INS not supported";
@@ -133,9 +133,9 @@ namespace LedgerWallet
 					return "OK";
 				default:
 					{
-						if ((status.SW & 0xFF00) != 0x6F00)
+						if((status.SW & 0xFF00) != 0x6F00)
 							return "Unknown error";
-						switch (status.InternalSW)
+						switch(status.InternalSW)
 						{
 							case 0xAA:
 								return "The dongle must be reinserted";
@@ -177,27 +177,26 @@ namespace LedgerWallet
 		{
 			var responses = await ExchangeAsync(apdus).ConfigureAwait(false);
 			var last = responses.Last();
-			foreach (var response in responses)
+			foreach(var response in responses)
 			{
-				if (response != last)
+				if(response != last)
 					CheckSW(OK, response.SW);
 			}
 			return last;
 		}
-
 		protected async Task<APDUResponse[]> ExchangeAsync(byte[][] apdus)
 		{
 			byte[][] responses = await Transport.ExchangeAsync(apdus).ConfigureAwait(false);
 			List<APDUResponse> resultResponses = new List<APDUResponse>();
-			foreach (var response in responses)
+			foreach(var response in responses)
 			{
-				if (response.Length < 2)
+				if(response.Length < 2)
 				{
 					throw new LedgerWalletException("Truncated response");
 				}
 				int sw = ((int)(response[response.Length - 2] & 0xff) << 8) |
 						(int)(response[response.Length - 1] & 0xff);
-				if (sw == 0x6faa)
+				if(sw == 0x6faa)
 					Throw(sw);
 				byte[] result = new byte[response.Length - 2];
 				Array.Copy(response, 0, result, 0, response.Length - 2);

--- a/LedgerWallet/Transports/HIDTransportBase.cs
+++ b/LedgerWallet/Transports/HIDTransportBase.cs
@@ -232,7 +232,7 @@ namespace LedgerWallet.Transports
 
 		internal async Task<int> hid_read_timeout(IntPtr hidDeviceObject, byte[] buffer, uint length)
 		{
-			var result = await this._Device.ReadAsync((int)ReadTimeout.TotalMilliseconds);
+			var result = this._Device.Read((int)ReadTimeout.TotalMilliseconds);
 			if(result.Status == HidDeviceData.ReadStatus.Success)
 			{
 				if(result.Data.Length - 1 > length)
@@ -247,7 +247,7 @@ namespace LedgerWallet.Transports
 		{
 			byte[] sent = new byte[length + 1];
 			Array.Copy(buffer, 0, sent, 1, length);
-			if(!await this._Device.WriteAsync(sent))
+			if(!this._Device.Write(sent))
 				return -1;
 			Array.Copy(sent, 0, buffer, 0, length);
 			return length;

--- a/LedgerWallet/Transports/HIDTransportBase.cs
+++ b/LedgerWallet/Transports/HIDTransportBase.cs
@@ -83,7 +83,7 @@ namespace LedgerWallet.Transports
 		protected SemaphoreSlim _SemaphoreSlim = new SemaphoreSlim(1, 1)
 ;
 		bool initializing = false;
-		public async Task<byte[][]> ExchangeAsync(byte[][] apdus)
+		public async Task<byte[][]> Exchange(byte[][] apdus)
 		{
 			if(needInit && !initializing)
 			{

--- a/LedgerWallet/Transports/HIDTransportBase.cs
+++ b/LedgerWallet/Transports/HIDTransportBase.cs
@@ -86,7 +86,7 @@ namespace LedgerWallet.Transports
 		}
 
 		bool initializing = false;
-		public async Task<byte[][]> Exchange(byte[][] apdus)
+		public async Task<byte[][]> ExchangeAsync(byte[][] apdus)
 		{
 			if(needInit && !initializing)
 			{

--- a/LedgerWallet/Transports/HIDTransportBase.cs
+++ b/LedgerWallet/Transports/HIDTransportBase.cs
@@ -232,6 +232,7 @@ namespace LedgerWallet.Transports
 
 		internal async Task<int> hid_read_timeout(IntPtr hidDeviceObject, byte[] buffer, uint length)
 		{
+			//ReadAsync isn't supported with this library
 			var result = this._Device.Read((int)ReadTimeout.TotalMilliseconds);
 			if(result.Status == HidDeviceData.ReadStatus.Success)
 			{
@@ -247,6 +248,7 @@ namespace LedgerWallet.Transports
 		{
 			byte[] sent = new byte[length + 1];
 			Array.Copy(buffer, 0, sent, 1, length);
+			//WriteAsync isn't supported with this library
 			if(!this._Device.Write(sent))
 				return -1;
 			Array.Copy(sent, 0, buffer, 0, length);

--- a/LedgerWallet/Transports/HIDU2FTransport.cs
+++ b/LedgerWallet/Transports/HIDU2FTransport.cs
@@ -107,7 +107,7 @@ namespace LedgerWallet.Transports
 			_Registry = new HIDDeviceTransportRegistry<HIDU2FTransport>(d => new HIDU2FTransport(d));
 		}
 
-		protected override void Init()
+		protected async override Task InitAsync()
 		{
 			using(this.Lock())
 			{
@@ -117,10 +117,10 @@ namespace LedgerWallet.Transports
 					var nonce = RandomUtils.GetBytes(8);
 					var readenNonce = nonce.ToArray();
 					byte[] response;
-					Write(nonce);
+					await WriteAsync(nonce);
 					do
 					{
-						response = Read();
+						response = await ReadAsync();
 						if(response == null)
 							throw new LedgerWalletException("Error while transmission");
 						Array.Copy(response, 0, readenNonce, 0, nonce.Length);

--- a/LedgerWallet/Transports/HIDU2FTransport.cs
+++ b/LedgerWallet/Transports/HIDU2FTransport.cs
@@ -134,7 +134,6 @@ namespace LedgerWallet.Transports
 			}
 		}
 
-
 		static UsageSpecification[] _UsageSpecification = new[] { new UsageSpecification(0xf1d0, 0x01) };
 		public static unsafe IEnumerable<HIDU2FTransport> GetHIDTransports(IEnumerable<VendorProductIds> ids = null)
 		{

--- a/LedgerWallet/Transports/HIDU2FTransport.cs
+++ b/LedgerWallet/Transports/HIDU2FTransport.cs
@@ -109,95 +109,96 @@ namespace LedgerWallet.Transports
 
 		protected async override Task InitAsync()
 		{
-			using(this.Lock())
+			await _SemaphoreSlim.WaitAsync();
+
+			cmd = CMD_INIT;
+			try
 			{
-				cmd = CMD_INIT;
-				try
+				var nonce = RandomUtils.GetBytes(8);
+				var readenNonce = nonce.ToArray();
+				byte[] response;
+				await WriteAsync(nonce);
+				do
 				{
-					var nonce = RandomUtils.GetBytes(8);
-					var readenNonce = nonce.ToArray();
-					byte[] response;
-					await WriteAsync(nonce);
-					do
-					{
-						response = await ReadAsync();
-						if(response == null)
-							throw new LedgerWalletException("Error while transmission");
-						Array.Copy(response, 0, readenNonce, 0, nonce.Length);
-					} while(!readenNonce.SequenceEqual(nonce));
-					Array.Copy(response, 8, cid, 0, cid.Length);
-				}
-				finally
-				{
-					cmd = CMD_APDU;
-				}
+					response = await ReadAsync();
+					if(response == null)
+						throw new LedgerWalletException("Error while transmission");
+					Array.Copy(response, 0, readenNonce, 0, nonce.Length);
+				} while(!readenNonce.SequenceEqual(nonce));
+				Array.Copy(response, 8, cid, 0, cid.Length);
 			}
-		}
-
-		static UsageSpecification[] _UsageSpecification = new[] { new UsageSpecification(0xf1d0, 0x01) };
-		public static unsafe IEnumerable<HIDU2FTransport> GetHIDTransports(IEnumerable<VendorProductIds> ids = null)
-		{
-			ids = ids ?? WellKnownU2F;
-			return _Registry.GetHIDTransports(ids, _UsageSpecification);
-		}
-
-		protected override byte[] WrapCommandAPDU(Stream command, ref int sequenceIdx)
-		{
-			MemoryStream output = new MemoryStream();
-			int position = (int)output.Position;
-			output.Write(cid, 0, cid.Length);
-			if(sequenceIdx == 0)
+			finally
 			{
-				output.WriteByte((byte)(TYPE_INIT | cmd));
-				output.WriteByte((byte)((command.Length >> 8) & 0xff));
-				output.WriteByte((byte)(command.Length & 0xff));
+				cmd = CMD_APDU;
+				_SemaphoreSlim.Release();
 			}
-			else
-			{
-				output.WriteByte((byte)((sequenceIdx - 1) & 0x7f));
-			}
-			var headerSize = (int)(output.Position - position);
-			int blockSize = Math.Min(U2F_HID_PACKET_SIZE - headerSize, (int)command.Length - (int)command.Position);
-			var commantPart = command.ReadBytes(blockSize);
-			output.Write(commantPart, 0, commantPart.Length);
-			while((output.Length % U2F_HID_PACKET_SIZE) != 0)
-				output.WriteByte(0);
-			sequenceIdx++;
-			Debug.Assert(output.Length == U2F_HID_PACKET_SIZE);
-			return output.ToArray();
-		}
-
-		protected override byte[] UnwrapReponseAPDU(byte[] data, ref int sequenceIdx, ref int remaining)
-		{
-			MemoryStream output = new MemoryStream();
-			MemoryStream input = new MemoryStream(data);
-			int position = (int)input.Position;
-			if(!input.ReadBytes(cid.Length).SequenceEqual(cid))
-				return null;
-			var cmd = input.ReadByte();
-
-			if(sequenceIdx == 0)
-			{
-				if(cmd != (TYPE_INIT | this.cmd) && cmd != STAT_ERR)
-					return null;
-				remaining = ((input.ReadByte()) << 8);
-				remaining |= input.ReadByte();
-			}
-
-			if(cmd == STAT_ERR)
-				throw new U2FException((byte)input.ReadByte());
-
-			if(sequenceIdx != 0 && cmd != (0x7f & (sequenceIdx - 1)))
-				return null;
-			var headerSize = input.Position - position;
-			var blockSize = (int)Math.Min(remaining, U2F_HID_PACKET_SIZE - headerSize);
-			byte[] commandPart = new byte[blockSize];
-			if(input.Read(commandPart, 0, commandPart.Length) != commandPart.Length)
-				return null;
-			output.Write(commandPart, 0, commandPart.Length);
-			remaining -= blockSize;
-			sequenceIdx++;
-			return output.ToArray();
 		}
 	}
+
+	static UsageSpecification[] _UsageSpecification = new[] { new UsageSpecification(0xf1d0, 0x01) };
+	public static unsafe IEnumerable<HIDU2FTransport> GetHIDTransports(IEnumerable<VendorProductIds> ids = null)
+	{
+		ids = ids ?? WellKnownU2F;
+		return _Registry.GetHIDTransports(ids, _UsageSpecification);
+	}
+
+	protected override byte[] WrapCommandAPDU(Stream command, ref int sequenceIdx)
+	{
+		MemoryStream output = new MemoryStream();
+		int position = (int)output.Position;
+		output.Write(cid, 0, cid.Length);
+		if(sequenceIdx == 0)
+		{
+			output.WriteByte((byte)(TYPE_INIT | cmd));
+			output.WriteByte((byte)((command.Length >> 8) & 0xff));
+			output.WriteByte((byte)(command.Length & 0xff));
+		}
+		else
+		{
+			output.WriteByte((byte)((sequenceIdx - 1) & 0x7f));
+		}
+		var headerSize = (int)(output.Position - position);
+		int blockSize = Math.Min(U2F_HID_PACKET_SIZE - headerSize, (int)command.Length - (int)command.Position);
+		var commantPart = command.ReadBytes(blockSize);
+		output.Write(commantPart, 0, commantPart.Length);
+		while((output.Length % U2F_HID_PACKET_SIZE) != 0)
+			output.WriteByte(0);
+		sequenceIdx++;
+		Debug.Assert(output.Length == U2F_HID_PACKET_SIZE);
+		return output.ToArray();
+	}
+
+	protected override byte[] UnwrapReponseAPDU(byte[] data, ref int sequenceIdx, ref int remaining)
+	{
+		MemoryStream output = new MemoryStream();
+		MemoryStream input = new MemoryStream(data);
+		int position = (int)input.Position;
+		if(!input.ReadBytes(cid.Length).SequenceEqual(cid))
+			return null;
+		var cmd = input.ReadByte();
+
+		if(sequenceIdx == 0)
+		{
+			if(cmd != (TYPE_INIT | this.cmd) && cmd != STAT_ERR)
+				return null;
+			remaining = ((input.ReadByte()) << 8);
+			remaining |= input.ReadByte();
+		}
+
+		if(cmd == STAT_ERR)
+			throw new U2FException((byte)input.ReadByte());
+
+		if(sequenceIdx != 0 && cmd != (0x7f & (sequenceIdx - 1)))
+			return null;
+		var headerSize = input.Position - position;
+		var blockSize = (int)Math.Min(remaining, U2F_HID_PACKET_SIZE - headerSize);
+		byte[] commandPart = new byte[blockSize];
+		if(input.Read(commandPart, 0, commandPart.Length) != commandPart.Length)
+			return null;
+		output.Write(commandPart, 0, commandPart.Length);
+		remaining -= blockSize;
+		sequenceIdx++;
+		return output.ToArray();
+	}
+}
 }

--- a/LedgerWallet/Transports/ILedgerTransport.cs
+++ b/LedgerWallet/Transports/ILedgerTransport.cs
@@ -8,6 +8,6 @@ namespace LedgerWallet.Transports
 {
 	public interface ILedgerTransport
 	{
-		Task<byte[][]> Exchange(byte[][] apdus);
+		Task<byte[][]> ExchangeAsync(byte[][] apdus);
 	}
 }

--- a/LedgerWallet/Transports/ILedgerTransport.cs
+++ b/LedgerWallet/Transports/ILedgerTransport.cs
@@ -8,6 +8,6 @@ namespace LedgerWallet.Transports
 {
 	public interface ILedgerTransport
 	{
-		Task<byte[][]> ExchangeAsync(byte[][] apdus);
+		Task<byte[][]> Exchange(byte[][] apdus);
 	}
 }

--- a/LedgerWallet/U2FClient.cs
+++ b/LedgerWallet/U2FClient.cs
@@ -266,7 +266,7 @@ namespace LedgerWallet.U2F
 					apduStream.Write(data, 0, data.Length);
 					apduStream.WriteByte(0x04);
 					apduStream.WriteByte(0);
-					return await ExchangeApdus(new byte[][] { apduStream.ToArray() }, OK).ConfigureAwait(false);
+					return await ExchangeApdusAsync(new byte[][] { apduStream.ToArray() }, OK).ConfigureAwait(false);
 				}
 				catch(LedgerWalletException ex)
 				{
@@ -284,7 +284,7 @@ namespace LedgerWallet.U2F
 			apdu[2] = p1;
 			apdu[3] = p2;
 			Array.Copy(data, 0, apdu, 4, data.Length);
-			return ExchangeSingle(new byte[][] { apdu });
+			return ExchangeSingleAsync(new byte[][] { apdu });
 		}
 
 	}


### PR DESCRIPTION
- Convert all synchronous code to Task based async
- Convert Unit tests to work using await keyword

**Breaking changes**
- All async calls must be awaited
- All async calls are suffixed with Async

_Note: this is the first step to getting the code to work across all platforms: especially UWP._ 